### PR TITLE
Inject starting timestamp into Spotify iframe

### DIFF
--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -278,7 +278,7 @@ class App extends Component {
                 <tr>
                 <th>Spotify</th>
                 <td>
-                  {this.renderLoadButton('spotify:track:6Uwi2Qk3H7fM4b4W4ExrAp', 'Test A')}
+                  {this.renderLoadButton('https://open.spotify.com/episode/6X2w9HzSvDfGg9oDozO4VA?si=2ySbuYAiT6eooSO2T8MvTw', 'Test A')}
                   {this.renderLoadButton('spotify:track:0KhB428j00T8lxKCpHweKw', 'Test B')}
                 </td>
               </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexaai/react-player",
-  "version": "2.13.1",
+  "version": "2.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexaai/react-player",
-      "version": "2.13.1",
+      "version": "2.13.4",
       "dependencies": {
         "deepmerge": "^4.0.0",
         "load-script": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexaai/react-player",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "A React component for playing a variety of URLs, including file paths, YouTube, Facebook, Twitch, SoundCloud, Streamable, Vimeo, Wistia and DailyMotion",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,6 +58,18 @@ export function queryString (object) {
     .join('&')
 }
 
+export function addQueryParam (url, param, value) {
+  const urlObject = new URL(url);
+
+  if (urlObject.searchParams.has(param)) {
+    urlObject.searchParams.set(param, value);
+  } else {
+    urlObject.searchParams.append(param, value);
+  }
+  
+  return urlObject.href;
+}
+
 function getGlobal (key) {
   if (window[key]) {
     return window[key]


### PR DESCRIPTION
This is a more solid bandaid fix that injects the starting timestamp into Spotify's iframe src.

See https://community.spotify.com/t5/Spotify-for-Developers/iframe-API-startAt-bug/td-p/5661113 for more details